### PR TITLE
Deploy only on push to main

### DIFF
--- a/.github/workflows/build_website.yaml
+++ b/.github/workflows/build_website.yaml
@@ -5,8 +5,6 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-    branches:
-      - main
   repository_dispatch:
     types: [new-profiling-results]
 

--- a/.github/workflows/build_website.yaml
+++ b/.github/workflows/build_website.yaml
@@ -78,13 +78,13 @@ jobs:
           path: build/*
           retention-days: 1
 
-  # Only deploy the website on pushes to main
+  # Only deploy the website when the workflow was triggered on main
   # This allows the previous two jobs to be used as checks against PRs
   deploy-website:
     name: Deploy pages site
     runs-on: ubuntu-latest
     needs: [docs-build, profiling-build]
-    if: (github.event_name == 'push' || github.event_name == 'repository_dispatch') && github.ref_name == 'main'
+    if: github.ref_name == 'main' || github.event_name == 'repository_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build_website.yaml
+++ b/.github/workflows/build_website.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Upload the generated HTML
       uses: actions/upload-artifact@v3
       with:
-        name: dev_docs_html
+        name: dev_docs_html_${{ github.sha }}
         path: html/*
         retention-days: 1
 
@@ -76,7 +76,7 @@ jobs:
       - name: Upload the generated HTML
         uses: actions/upload-artifact@v3
         with:
-          name: profiling_results_html
+          name: profiling_results_html_${{ github.sha }}
           path: build/*
           retention-days: 1
 
@@ -94,13 +94,13 @@ jobs:
       - name: Fetch profiling results html
         uses: actions/download-artifact@v3
         with:
-          name: profiling_results_html
+          name: profiling_results_html_${{ github.sha }}
           path: build/
 
       - name: Fetch developer docs html
         uses: actions/download-artifact@v3
         with:
-          name: dev_docs_html
+          name: dev_docs_html_${{ github.sha }}
           path: dev
 
       - name: Move doxygen files into build folder

--- a/.github/workflows/build_website.yaml
+++ b/.github/workflows/build_website.yaml
@@ -84,7 +84,7 @@ jobs:
     name: Deploy pages site
     runs-on: ubuntu-latest
     needs: [docs-build, profiling-build]
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: (github.event_name == 'push' || github.event_name == 'repository_dispatch') && github.ref_name == 'main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Checks should be run but deployment _should not_ happen!

Forces artifacts to have names unique to the commit they were triggered on, so we don't interfere with the active deployment on `main`.

This also allows workflows to be triggered on any branch dispatch, since deployment will only happen on pushes to main, or on the triggered event.